### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
This .gitattributes file can let GitHub's language statistic function recognize .md file to Markdown language.
![image](https://user-images.githubusercontent.com/75297777/145145989-420fa159-9064-495e-838c-1cc913ede43e.png)