### PR TITLE
Remove `contribute` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Improve your README.md profile with these amazing badges. See a sample [here](ht
         - [🤖 Artificial Intelligence](#-artificial-intelligence-)
         - [📝 Blog](#-blog-)
         - [📱 Contact](#-contact-)
-        - [✏ Contribute](#-contribute-)
         - [☁ Cloud](#-cloud-)
         - [💲 Cryptocurrency](#-cryptocurrency-)
         - [⚡ Database](#-database-)


### PR DESCRIPTION
- Remove `contribute` option from menu due to no section exist with this name.