### PR TITLE
Added 🧵 thread-count: Status badges for Threads.net follower counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,14 @@ Improve your README.md profile with these amazing badges. See a sample [here](ht
 | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | <img width='200' src="https://github-profile-trophy.vercel.app/?username=alexandresanlim" /> | `https://github-profile-trophy.vercel.app/?username={username}` | `https://github-profile-trophy.vercel.app/?username={username}&theme={theme_name}` |
 
+## 🧵 Thread Count: Custom status badges for Meta's Threads.net follower counts
+
+- Customizable: `colors`, `scale`, `text` etc.
+
+| Badge                                                                                        | URL                                                             | Theme                                                                              |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| <a href="https://github.com/AayushGithub/thread-count"><img src="https://thread-count.vercel.app/thread-count/zuck?label=Follower%20Count&labelColor=white" alt="Thread Count: Custom status badges for Meta's Threads.net follower counts"></a>  | `https://thread-count.vercel.app/thread-count/{username}` | `https://thread-count.vercel.app/thread-count/{username}?color={color}&gradient={true}&scale={scale}` |
+
 ## ✏ How To Contribute [🔝](#welcome-badges-4-readmemd-profile)
 
 1 - You don't need to make a fork just edit.


### PR DESCRIPTION
[Thread Count](https://thread-count.vercel.app/) is a service that allows you to generate custom status badges displaying Meta's Threads.net follower counts. You can customize the badge color, style, width, scale, label color, and more. The generated badges are in SVG format and can be easily embedded into your markdown files, websites, or any other platform that supports SVG images.

<a href="https://www.threads.net/@zuck"><img src="https://thread-count.vercel.app/thread-count/zuck" alt="Default Badge"></a>

Thank you for your support!!