### PR TITLE
visual error fixed in sponsor buttons on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@
 </p>
 
 <p align='center'>
- <a href="https://github.com/sponsors/alexandresanlim">
-    <img src="https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#white" />
-  </a>&nbsp;&nbsp;
-  <a href="#">
-  <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/alexandresanlim/Badges4-README.md-Profile?style=for-the-badge">
-</a>&nbsp;&nbsp;
+  <a href="https://github.com/sponsors/alexandresanlim"><img alt="Sponsor" src="https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#white" /></a>
+  &nbsp;
+  <a href="#"><img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/alexandresanlim/Badges4-README.md-Profile?style=for-the-badge" /></a>
 </p>
 <br />
 


### PR DESCRIPTION
I remove the space in sponsor links

## Before

![image](https://github.com/user-attachments/assets/a8bec9a2-e499-4c09-8315-2b1d88e25451)


## After
![image](https://github.com/user-attachments/assets/239c958b-c8c4-4d18-af24-92cc224719d3)

