### PR TITLE
Add n8n badge to Low Code Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ or
 | Badge                                                                                                    | URL                                                                                          |
 | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | <img src="https://img.shields.io/badge/Appian-2322F0?style=for-the-badge&logo=Appian&logoColor=white" /> | `https://img.shields.io/badge/Appian-2322F0?style=for-the-badge&logo=Appian&logoColor=white` |
+| <img src="https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white&logoSize=auto" />       | `https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white&logoSize=auto`       |
 
 ## 📱 Mobile Frameworks [🔝](#menu)
 


### PR DESCRIPTION
## Add n8n badge to Low Code Platforms section

This PR adds a badge entry for **n8n** to the Low Code Platforms section of the README.

### Changes
- Added n8n badge with EA4B71 color
- Included logo and logoColor parameters
- Used `logoSize=auto` parameter for optimal logo sizing
- Follows the existing document pattern

### Badge
<img src="https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white&logoSize=auto" />