### PR TITLE
Add esphome badge to HomeLab section

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ or
 | <img src="https://img.shields.io/badge/Home%20Assistant-18BCF2?style=for-the-badge&logo=Home%20Assistant&logoColor=white" />                            | `https://img.shields.io/badge/Home%20Assistant-18BCF2?style=for-the-badge&logo=Home%20Assistant&logoColor=white`                            |
 | <img src="https://img.shields.io/badge/immich-black?logo=immich&logoColor=fa2921&style=for-the-badge&labelColor=ffb400&color=ffb400" /> | `https://img.shields.io/badge/immich-black?logo=immich&logoColor=fa2921&style=for-the-badge&labelColor=ffb400&color=ffb400` |
 | <img src="https://img.shields.io/badge/rustdesk-024EFF?style=for-the-badge&logo=rustdesk&logoColor=white" />                            | `https://img.shields.io/badge/rustdesk-024EFF?style=for-the-badge&logo=rustdesk&logoColor=white`                            |
+| <img src="https://img.shields.io/badge/esphome-white?style=for-the-badge&logo=esphome&logoColor=black&logoSize=auto" />                 | `https://img.shields.io/badge/esphome-white?style=for-the-badge&logo=esphome&logoColor=black&logoSize=auto`                 |
 
 ## 👩‍💻 IDE [🔝](#menu)
 


### PR DESCRIPTION
## Description
This PR adds a badge entry for **ESPHome** to the HomeLab section of the README.

## Changes
- Added ESPHome badge with white background
- Included logo with black text (`logoColor=black`)
- Used `logoSize=auto` parameter for optimal logo sizing
- Follows the existing document pattern

## Badge Preview
<img src="https://img.shields.io/badge/esphome-white?style=for-the-badge&logo=esphome&logoColor=black&logoSize=auto" />

## Section
🏠 HomeLab

## Notes
ESPHome is an open-source framework for building IoT devices using ESP8266/ESP32 boards, providing an easy way to configure smart devices through YAML.

